### PR TITLE
allow authorization header or jwt cookies

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,8 +87,11 @@ async fn main() -> anyhow::Result<()> {
             csrf: Option<String>,
         }
 
-        let auth = warp::header::optional("authorization")
-            .or(warp::cookie::optional("jwt"))
+        let auth = warp::header("authorization")
+            .or(warp::cookie("jwt"))
+            .unify()
+            .map(Some)
+            .or(warp::any().map(|| None))
             .unify()
             .and(warp::query())
             .and_then(|jwt: Option<String>, query: Query| async {


### PR DESCRIPTION
Unfortunately due to the way `unify` works, we have to do [a little more work](https://github.com/seanmonstar/warp/issues/658#issuecomment-660409260) to make this work.